### PR TITLE
Fix Build for Node.js environment

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -6,7 +6,7 @@ function buildFetchFunction <P extends Record<string, string | undefined>, R>(te
   return async (params: P = {} as P) => {
     const url = templateUrl.replace(/{(\w+)}/g, (_, key) => {
       const value = params[key]
-      if (!value) throw Error('Missing required parameter', key)
+      if (!value) throw Error(`Missing required parameter ${key}`)
 
       delete params[key]
       return encodeURIComponent(value)


### PR DESCRIPTION
### Fix invalid `Error` constructor usage

Replaced incorrect `Error('msg', key)` call with a valid single-argument version:

```ts
throw new Error(`Missing required parameter ${key}`);
```

This fixes a TypeScript build error (`TS2554`) caused by incorrect argument count passed to the `Error` constructor.